### PR TITLE
Handling not PNG files properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,8 +23,12 @@
       if (err) {
         return callback(err);
       }
-      output = revertCgBIBuffer(buffer);
-      return callback(null, streamifier.createReadStream(output));
+      try {
+        output = revertCgBIBuffer(buffer);
+        return callback(null, streamifier.createReadStream(output));
+      } catch (e) {
+        return callback(e);
+      }
     });
   };
 


### PR DESCRIPTION
Hi @jakubknejzlik!

Found a bug in your lib. When this line throws an exception: https://github.com/jakubknejzlik/cgbi-to-png/blob/master/index.js#L40 (when file is not a valid PNG ) then callback won't return with that error.